### PR TITLE
Update README.md (missing test dependency for Ubuntu/Debian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Kvrocks has the following key features:
 ## Building kvrocks
 
 #### requirements
-
+ 
 * g++ (required by c++11, version >= 4.8)
 * autoconf automake libtool snappy
 
@@ -56,7 +56,7 @@ sudo yum install -y epel-release && sudo yum install -y git gcc gcc-c++ make sna
 
 # Ubuntu/Debian
 sudo apt update
-sudo apt-get install gcc g++ make libsnappy-dev autoconf automake libtool
+sudo apt-get install gcc g++ make libsnappy-dev autoconf automake libtool googletest googletest-tools libgmock-dev libgtest-dev google-mock
 
 # MACOSX
 brew install autoconf automake libtool snappy googletest


### PR DESCRIPTION
Add missing googletest dependency in build instruction for Ubuntu/Debian